### PR TITLE
Add support for nightmode

### DIFF
--- a/lib/LimitlessLEDRGB.js
+++ b/lib/LimitlessLEDRGB.js
@@ -113,7 +113,6 @@ LimitlessLEDRGB.prototype.write = function(data) {
     var brightness = parsed.bri / 254.0;
     var on = parsed.on;
     var temp = parsed.ct;
-    var nightmode = parsed.nightmode;
     
     if ( this.lightGroup.colorType == 'rgb' ) {
       var cb = function() {

--- a/lib/LimitlessLEDRGB.js
+++ b/lib/LimitlessLEDRGB.js
@@ -22,7 +22,7 @@ const valByteNA = 0x00;
 const cmdEndByte = 0x55;
 
 var whiteLightGroupCommands = {
-  "all": { "on": 0x35, "off": 0x39 },
+  "all": { "on": 0x35, "off": 0x39, "night": 0xB9 },
   "1": { "on": 0x38, "off": 0x3B, "night": 0xBB },
   "2": { "on": 0x3D, "off": 0x33, "night": 0xB3 },
   "3": { "on": 0x37, "off": 0x3A, "night": 0xBA },
@@ -113,6 +113,7 @@ LimitlessLEDRGB.prototype.write = function(data) {
     var brightness = parsed.bri / 254.0;
     var on = parsed.on;
     var temp = parsed.ct;
+    var nightmode = parsed.nightmode;
     
     if ( this.lightGroup.colorType == 'rgb' ) {
       var cb = function() {
@@ -141,17 +142,13 @@ LimitlessLEDRGB.prototype.write = function(data) {
         var self = this;
         
         // FIXME: add support for temperature
-	    // Treat a brightness of zero as 'moon' or 'night' mode
-        if (brightness == 0) {
-			  console.log("Nightmode on");
-			  this.sendWhiteGroupCommand( 'night' );
-        } else {
-				self.sendWhiteGroupCommand( 'on', function() {
-				  self.doBrightnessVoodoo( brightness, function() {
-				    // now do the temperature change
-		            self.doWarmthVoodoo( (temp - 154.0) / (500.0 - 154.0) );
-		          } );
-		        } );
+        
+        self.sendWhiteGroupCommand( 'on', function() {
+          self.doBrightnessVoodoo( brightness, function() {
+            // now do the temperature change
+            self.doWarmthVoodoo( (temp - 154.0) / (500.0 - 154.0) );
+          } );
+        } );
       } else {
         this.sendWhiteGroupCommand( 'off' );
       }

--- a/lib/LimitlessLEDRGB.js
+++ b/lib/LimitlessLEDRGB.js
@@ -23,10 +23,10 @@ const cmdEndByte = 0x55;
 
 var whiteLightGroupCommands = {
   "all": { "on": 0x35, "off": 0x39 },
-  "1": { "on": 0x38, "off": 0x3B },
-  "2": { "on": 0x3D, "off": 0x33 },
-  "3": { "on": 0x37, "off": 0x3A },
-  "4": { "on": 0x32, "off": 0x36 },
+  "1": { "on": 0x38, "off": 0x3B, "night": 0xBB },
+  "2": { "on": 0x3D, "off": 0x33, "night": 0xB3 },
+  "3": { "on": 0x37, "off": 0x3A, "night": 0xBA },
+  "4": { "on": 0x32, "off": 0x36, "night": 0xB6 },
 }
 
 /**
@@ -141,13 +141,17 @@ LimitlessLEDRGB.prototype.write = function(data) {
         var self = this;
         
         // FIXME: add support for temperature
-        
-        self.sendWhiteGroupCommand( 'on', function() {
-          self.doBrightnessVoodoo( brightness, function() {
-            // now do the temperature change
-            self.doWarmthVoodoo( (temp - 154.0) / (500.0 - 154.0) );
-          } );
-        } );
+	    // Treat a brightness of zero as 'moon' or 'night' mode
+        if (brightness == 0) {
+			  console.log("Nightmode on");
+			  this.sendWhiteGroupCommand( 'night' );
+        } else {
+				self.sendWhiteGroupCommand( 'on', function() {
+				  self.doBrightnessVoodoo( brightness, function() {
+				    // now do the temperature change
+		            self.doWarmthVoodoo( (temp - 154.0) / (500.0 - 154.0) );
+		          } );
+		        } );
       } else {
         this.sendWhiteGroupCommand( 'off' );
       }


### PR DESCRIPTION
White Limitless LEDs support a low power 'night mode'.  I've included support for enabling this on all groups and each of groups 1 to 4.

When the LED is in a state where it is on but brightness is set to zero nightmode (also called 'moon mode') is now enabled.
